### PR TITLE
write Cucumber features for everything

### DIFF
--- a/.config/cucumber.yml
+++ b/.config/cucumber.yml
@@ -1,1 +1,2 @@
-default: --fail-fast
+default: --fail-fast --tags '@no-clobber'
+bootstrap: --tags "@bootstrap"

--- a/features/00 - Installation.feature
+++ b/features/00 - Installation.feature
@@ -1,5 +1,5 @@
-Feature: 01. Installation
-    @disable-bundler
+@disable-bundler
+Feature: 00. Installation
     Scenario: 01. Bootstrapping
         # High timeout, we're building and installing stuff
         Given the aruba exit timeout is 3600 seconds

--- a/features/00 - Installation.feature
+++ b/features/00 - Installation.feature
@@ -1,5 +1,6 @@
 @disable-bundler
 Feature: 00. Installation
+    @bootstrap
     Scenario: 01. Bootstrapping
         # High timeout, we're building and installing stuff
         Given the aruba exit timeout is 3600 seconds

--- a/features/01 - Basics/01 - Getting Started.feature
+++ b/features/01 - Basics/01 - Getting Started.feature
@@ -1,6 +1,6 @@
+@disable-bundler
+@no-clobber
 Feature: 01. Getting Started
-    @disable-bundler
-    @no-clobber
     Scenario: 01. Creating the bundle
         Given I cd to "dev"
         And within the workspace, I successfully run the following script:
@@ -27,8 +27,6 @@ Feature: 01. Getting Started
         When I stop the command started last
         Then the exit status should be 0
 
-    @disable-bundler
-    @no-clobber
     Scenario: 02. Setting up the scene
         Given I cd to "dev/bundles/syskit_basics"
         And a file named "scenes/empty_world/empty_world.world" with:
@@ -58,8 +56,6 @@ Feature: 01. Getting Started
         rock-gazebo --download-only empty_world
         """
 
-    @disable-bundler
-    @no-clobber
     Scenario: 03. Preparing the gazebo Syskit configuration
         Given I cd to "dev/bundles/syskit_basics"
         Then I successfully run the following script:

--- a/features/01 - Basics/02 - Compositions.feature
+++ b/features/01 - Basics/02 - Compositions.feature
@@ -1,6 +1,6 @@
+@disable-bundler
+@no-clobber
 Feature: 02. Compositions
-    @disable-bundler
-    @no-clobber
     Scenario: 01. Installing the necessary packages
         Given I cd to "dev"
         And I modify the file "autoproj/manifest" with:
@@ -15,8 +15,6 @@ Feature: 02. Compositions
         amake --all
         """
 
-    @disable-bundler
-    @no-clobber
     Scenario: 02. Using the installed component
         Given I cd to "dev/bundles/syskit_basics"
         And within the workspace, I successfully run the following script:

--- a/features/01 - Basics/03 - Constant Generator.feature
+++ b/features/01 - Basics/03 - Constant Generator.feature
@@ -1,6 +1,6 @@
+@disable-bundler
+@no-clobber
 Feature: 03. Constant Generator
-    @disable-bundler
-    @no-clobber
     Scenario: 01. The Cartesian Command Generator
         Given I cd to "dev/bundles/syskit_basics"
         And within the workspace, I successfully run the following script:
@@ -58,8 +58,6 @@ Feature: 03. Constant Generator
         """
         Then the file "models/compositions/arm_cartesian_constant_command_generator.rb" is valid for Syskit
 
-    @disable-bundler
-    @no-clobber
     Scenario: 02. Testing
         Given I cd to "dev/bundles/syskit_basics"
 
@@ -160,8 +158,6 @@ Feature: 03. Constant Generator
         syskit test -rgazebo test/compositions/test_arm_cartesian_constant_command_generator.rb
         """
 
-    @disable-bundler
-    @no-clobber
     Scenario: 03. Creating the ArmCartesianConstantControlWdls Composition
         Given I cd to "dev/bundles/syskit_basics"
         And within the workspace, I successfully run the following script:
@@ -218,8 +214,6 @@ Feature: 03. Constant Generator
         syskit test -r gazebo test/compositions/test_arm_cartesian_constant_control_wdls.rb
         """
 
-    @disable-bundler
-    @no-clobber
     Scenario: 04. The Joint Position Constant Generator
         Given I cd to "dev/bundles/syskit_basics"
         And within the workspace, I successfully run the following script:

--- a/features/01 - Basics/03 - Constant Generator.feature
+++ b/features/01 - Basics/03 - Constant Generator.feature
@@ -74,7 +74,7 @@ Feature: 03. Constant Generator
             end
         end
         """
-        Then the syskit test file "test/compositions/test_arm_cartesian_constant_command_generator.rb" passes
+        Then the Syskit test file "test/compositions/test_arm_cartesian_constant_command_generator.rb" passes
 
         When I modify the file "test/compositions/test_arm_cartesian_constant_command_generator.rb" with:
         """

--- a/features/01 - Basics/04 - Profiles and Devices.feature
+++ b/features/01 - Basics/04 - Profiles and Devices.feature
@@ -1,6 +1,6 @@
+@disable-bundler
+@no-clobber
 Feature: 04. Profiles and Devices
-    @disable-bundler
-    @no-clobber
     Scenario: 01. Defining Devices for the Gazebo System
         Given I cd to "dev/bundles/syskit_basics"
         When within the workspace, I successfully run the following script:

--- a/features/01 - Basics/05 - Deployment.feature
+++ b/features/01 - Basics/05 - Deployment.feature
@@ -1,9 +1,9 @@
+@disable-bundler
+@no-clobber
 Feature: 05. Deployment
     Background:
         Given I cd to "dev/bundles/syskit_basics"
 
-    @disable-bundler
-    @no-clobber
     Scenario: 01. Component Deployment
         When I modify the file "config/robots/gazebo.rb" with:
         """
@@ -23,8 +23,6 @@ Feature: 05. Deployment
         """
         Then the "gazebo" configuration is valid for Syskit
 
-    @disable-bundler
-    @no-clobber
     Scenario: 02. Static configuration of oroGen components
         When within the workspace, I successfully run the following script:
         """
@@ -73,8 +71,6 @@ Feature: 05. Deployment
         """
         Then the "gazebo" configuration is valid for Syskit
 
-    @disable-bundler
-    @no-clobber
     Scenario: 03. Dynamic and system-wide configuration
         When I modify the file "models/compositions/arm_cartesian_constant_control_wdls.rb" with:
         """
@@ -156,8 +152,6 @@ Feature: 05. Deployment
         """
         Then the "gazebo" configuration is valid for Syskit
 
-    @disable-bundler
-    @no-clobber
     Scenario: 04. Building the system's action interface
         When I modify the file "config/robots/gazebo.rb" with:
         """

--- a/features/01 - Basics/06 - Validation.feature
+++ b/features/01 - Basics/06 - Validation.feature
@@ -1,9 +1,9 @@
+@disable-bundler
+@no-clobber
 Feature: 06. Validation
     Background:
         Given I cd to "dev/bundles/syskit_basics"
 
-    @disable-bundler
-    @no-clobber
     Scenario: 01. Validating Configuration Consistency
         When I modify the file "models/orogen/cart_ctrl_wdls.rb" with:
             """

--- a/features/01 - Basics/06 - Validation.feature
+++ b/features/01 - Basics/06 - Validation.feature
@@ -118,3 +118,49 @@ Feature: 06. Validation
         """
         Then the Syskit test file "test/orogen/test_cart_ctrl_wdls.rb" passes in configuration "gazebo"
         Then the Syskit tests fail in configuration "gazebo"
+
+        When I modify the file "test/compositions/test_arm_cartesian_control_wdls.rb" with:
+        """
+                describe ArmCartesianControlWdls do
+        +           before do
+        +               # Create a mock that has a robot model
+        +               xml = <<-EOSDF
+        +                   <model name='test'>
+        +                   <link name="root_test" />
+        +                   <link name="tip_test" />
+        +                   </model>
+        +               EOSDF
+        +               @profile = flexmock(sdf_model: SDF::Model.from_xml_string(xml))
+        +               syskit_stub_conf OroGen.cart_ctrl_wdls.WDLSSolver, 'default',
+        +                   data: { 'root' => 'test::root_test', 'tip' => 'test::tip_test' }
+        +               syskit_stub_conf OroGen.robot_frames.SingleChainPublisher, 'default',
+        +                   data: { 'chain' => Hash['root_link' => 'test::root_test', 'tip_link' => 'test::tip_test'] }
+        +           end
+        -               cmp_task = syskit_stub_deploy_configure_and_start(ArmCartesianControlWdls)
+        +               cmp_task = syskit_stub_deploy_configure_and_start(
+        +                   ArmCartesianControlWdls.with_arguments(robot: @profile))
+        """
+        And I modify the file "test/compositions/test_arm_cartesian_constant_control_wdls.rb" with:
+        """
+                describe ArmCartesianConstantControlWdls do
+        +           before do
+        +               # Create a mock that has a robot model
+        +               xml = <<-EOSDF
+        +                   <model name='test'>
+        +                   <link name="root_test" />
+        +                   <link name="tip_test" />
+        +                   </model>
+        +               EOSDF
+        +               @profile = flexmock(sdf_model: SDF::Model.from_xml_string(xml))
+        +               syskit_stub_conf OroGen.cart_ctrl_wdls.WDLSSolver, 'default',
+        +                   data: { 'root' => 'test::root_test', 'tip' => 'test::tip_test' }
+        +               syskit_stub_conf OroGen.robot_frames.SingleChainPublisher, 'default',
+        +                   data: { 'chain' => Hash['root_link' => 'test::root_test', 'tip_link' => 'test::tip_test'] }
+        +           end
+        -               cmp = syskit_stub_deploy_configure_and_start(
+        -                   ArmCartesianConstantControlWdls.with_arguments(setpoint: setpoint))
+        +               cmp_task = syskit_stub_deploy_configure_and_start(
+        +                   ArmCartesianConstantControlWdls.with_arguments(
+        +                       setpoint: setpoint, robot: @profile))
+        """
+        Then the "gazebo" configuration is valid for Syskit

--- a/features/01 - Basics/07 - Publishing.feature
+++ b/features/01 - Basics/07 - Publishing.feature
@@ -1,8 +1,8 @@
+@disable-bundler
+@no-clobber
 Feature: 07. Publishing
     As a new Rock/Syskit user, I intend to learn how to integrate a new package.
 
-    @disable-bundler
-    @no-clobber
     @clobber-git
     @clobber-new_package_set
     Scenario: 01. Push the bundle
@@ -29,8 +29,6 @@ Feature: 07. Publishing
         """
         Then I push "master" to "bundles-syskit_basics"
 
-    @disable-bundler
-    @no-clobber
     Scenario: 02. Creating the new build configuration
         Given a git repository "rock.rock_and_syskit-buildconf"
         And I cd to "dev/autoproj"
@@ -49,8 +47,6 @@ Feature: 07. Publishing
         And I stop the command started last
         Then the exit status should be 0
 
-    @disable-bundler
-    @no-clobber
     Scenario: 03. Creating the new package set
         Given a git repository "rock.rock_and_syskit-package_set"
         And a directory named "new_package_set"
@@ -67,8 +63,6 @@ Feature: 07. Publishing
         """
         And I push "master" to "rock.rock_and_syskit-package_set"
 
-    @disable-bundler
-    @no-clobber
     Scenario: 04. Adding the package set to the build
         Given I cd to "dev"
         When I modify the file "autoproj/manifest" with:
@@ -85,8 +79,6 @@ Feature: 07. Publishing
         aup --config
         """
 
-    @disable-bundler
-    @no-clobber
     Scenario: 05. Defining the package
         Given I cd to "dev/autoproj/remotes/rock.rock_and_syskit"
         And I append to "packages.autobuild" with:
@@ -106,8 +98,6 @@ Feature: 07. Publishing
         aup -n syskit_basics
         """
 
-    @disable-bundler
-    @no-clobber
     Scenario: 06. Removing the control packages
         Given I cd to "dev"
         When I modify the file "autoproj/manifest" with:

--- a/features/01 - Basics/07 - Publishing.feature
+++ b/features/01 - Basics/07 - Publishing.feature
@@ -1,0 +1,121 @@
+Feature: 07. Publishing
+    As a new Rock/Syskit user, I intend to learn how to integrate a new package.
+
+    @disable-bundler
+    @no-clobber
+    @clobber-git
+    @clobber-new_package_set
+    Scenario: 01. Push the bundle
+        Given I cd to "dev/bundles/syskit_basics"
+        And a file named "manifest.xml" with:
+        """
+        <package>
+            <description brief="Syskit Tutorial Bundle from 'Rock and Syskit'">
+            </description>
+
+            <depend package="bundles/common_models" />
+            <depend package="simulation/rock_gazebo" />
+            <depend package="control/orogen/cart_ctrl_wdls" />
+            <depend package="control/orogen/robot_frames" />
+        </package>
+        """
+
+        And a git repository "bundles-syskit_basics"
+        When within the workspace, I successfully run the following script:
+        """
+        git init
+        git add .
+        git commit -m "Initial commit - Finished the Basics tutorial"
+        """
+        Then I push "master" to "bundles-syskit_basics"
+
+    @disable-bundler
+    @no-clobber
+    Scenario: 02. Creating the new build configuration
+        Given a git repository "rock.rock_and_syskit-buildconf"
+        And I cd to "dev/autoproj"
+        And within the workspace, I successfully run the following script:
+        """
+        git add .
+        git commit --allow-empty -m "Publishing the Basics tutorial results"
+        """
+        And I push "master" to "rock.rock_and_syskit-buildconf"
+        And I cd to ".."
+        When within the workspace, I run the following script interactively:
+        """
+        autoproj switch-config git ../git/rock.rock_and_syskit-buildconf.git
+        """
+        And I answer "y" to "delete the current configuration ? (required to switch)" 
+        And I stop the command started last
+        Then the exit status should be 0
+
+    @disable-bundler
+    @no-clobber
+    Scenario: 03. Creating the new package set
+        Given a git repository "rock.rock_and_syskit-package_set"
+        And a directory named "new_package_set"
+        When I cd to "new_package_set"
+        Then I successfully run the following script:
+        """
+        git init
+        echo "name: rock.rock_and_syskit" > source.yml
+        echo "version_control:" >> source.yml
+        echo "overrides:" >> source.yml
+        touch packages.autobuild packages.osdeps init.rb overrides.rb
+        git add .
+        git commit -m "Initial commit"
+        """
+        And I push "master" to "rock.rock_and_syskit-package_set"
+
+    @disable-bundler
+    @no-clobber
+    Scenario: 04. Adding the package set to the build
+        Given I cd to "dev"
+        When I modify the file "autoproj/manifest" with:
+        """
+        package_sets:
+        +  - type: git
+        +    url: $AUTOPROJ_ROOT/../git/rock.rock_and_syskit-package_set.git
+        layout:
+           - rock.gazebo
+        +  - rock.rock_and_syskit
+        """
+        Then within the workspace, I successfully run the following script:
+        """
+        aup --config
+        """
+
+    @disable-bundler
+    @no-clobber
+    Scenario: 05. Defining the package
+        Given I cd to "dev/autoproj/remotes/rock.rock_and_syskit"
+        And I append to "packages.autobuild" with:
+        """
+        bundle_package "bundles/syskit_basics"
+        """
+        And I modify the file "source.yml" with:
+        """
+        version_control:
+        +- bundles/syskit_basics:
+        + type: git
+        + url: $AUTOPROJ_ROOT/../git/bundles-syskit_basics.git
+        """
+        Then within the workspace, I successfully run the following script:
+        """
+        autoproj show syskit_basics
+        aup -n syskit_basics
+        """
+
+    @disable-bundler
+    @no-clobber
+    Scenario: 06. Removing the control packages
+        Given I cd to "dev"
+        When I modify the file "autoproj/manifest" with:
+        """
+        -  - control/orogen/cart_ctrl_wdls
+        -  - control/orogen/robot_frames
+        """
+        Then within the workspace, I successfully run the following script:
+        """
+        aup --config
+        """

--- a/features/10 - Testing and Debugging/01 - Syskit Integration.feature
+++ b/features/10 - Testing and Debugging/01 - Syskit Integration.feature
@@ -1,0 +1,82 @@
+@disable-bundler
+@no-clobber
+Feature: 14. Integration Tests
+    Background:
+        Given I cd to "dev/bundles/syskit_basics"
+
+    Scenario: 01.1 Installing Cucumber support
+        Given I modify the file "manifest.xml" with:
+        """
+            <depend package="control/orogen/robot_frames" />
+        +   <depend_optional name="bundles/cucumber" />
+        """
+        And within the workspace, I run the following script:
+        """
+        aup --checkout-only
+        """
+        Then within the workspace, I successfully run the following script:
+        """
+        cucumber --init
+        """
+
+    Scenario: 01.2 Setting up a Syskit app to use integration tests
+        Given the file "features/support/env.rb" with:
+        """
+        require 'cucumber/rock_world'
+        Cucumber::RockWorld.setup
+        World(
+            Roby::App::Cucumber::World,
+            RockGazebo::Syskit::Cucumber::World,
+            Cucumber::RockWorld)
+        """
+        And within the workspace, I successfully run the following script:
+        """
+        syskit gen action cucumber
+        """
+        And I overwrite the file "models/actions/cucumber.rb" with:
+        """
+        require 'cucumber/models/actions/cucumber'
+        require 'syskit_basics/models/profiles/gazebo/base'
+
+        module SyskitBasics
+            module Actions
+                class Cucumber < Cucumber::Actions::Cucumber
+                    def cucumber_robot_model
+                        # NOTE the device must be the root model, i.e. cannot use ur10_dev
+                        Profiles::Gazebo::Base.ur10_fixed_dev
+                    end
+                end
+            end
+        end
+        """
+        And within the workspace, I successfully run the following script:
+        """
+        syskit gen robot cucumber
+        """
+        And I modify the file "config/robots/cucumber.rb" with:
+        """
+        +require_relative './gazebo'
+        -Robot.requires do
+        ...
+        -end
+        +Robot.requires do
+        +   require 'syskit_basics/models/actions/cucumber'
+        +end
+        -Robot.actions do
+        ...
+        -end
+        +Robot.actions do
+        +   use_library SyskitBasics::Actions::Cucumber
+        +end
+        """
+        And the file "features/Test Setup.feature" with:
+        """
+        Feature: Checking the Syskit/Cucumber Test Setup
+            Scenario: Starting a simulation and a Syskit app under Cucumber
+                Given the cucumber robot starting at origin in the empty world
+                Then the pose reaches z=0m with a tolerance of 0.1m within 30s
+        """
+        Then within the workspace, I successfully run the following script:
+        """
+        cucumber "features/Test Setup.feature"
+        """

--- a/features/restore_aruba_state
+++ b/features/restore_aruba_state
@@ -1,0 +1,15 @@
+#! /usr/bin/env ruby
+
+rock_and_syskit_base_dir = File.expand_path("..", __dir__)
+aruba_dirname = "#{File.basename(rock_and_syskit_base_dir)}-dev"
+aruba_base_dir = File.expand_path(File.join("..", aruba_dirname), rock_and_syskit_base_dir)
+
+return unless File.directory?(aruba_base_dir)
+
+require_relative './support/save_state'
+
+raise "no feature file given" unless (feature_file = ARGV[0])
+
+feature_name, scenario_name = find_expected_scenario(feature_file, scenario: ARGV[1])
+puts "resetting before #{feature_name} - #{scenario_name}"
+restore_state_before_scenario(feature_name, scenario_name, aruba_base_dir)

--- a/features/step_definitions/aruba_autoproj_steps.rb
+++ b/features/step_definitions/aruba_autoproj_steps.rb
@@ -20,7 +20,7 @@ Then(/^within the workspace, I successfully run the following script for up to (
     step "I successfully run the following script for up to #{timeout} seconds:", make_workspace_script(script)
 end
 
-Then(/^within the workspace, I successfully run the following script:$/) do |script|
+Then("within the workspace, I successfully run the following script:") do |script|
     step "I successfully run the following script:", make_workspace_script(script)
 end
 

--- a/features/step_definitions/git_steps.rb
+++ b/features/step_definitions/git_steps.rb
@@ -1,0 +1,16 @@
+
+def aruba_git_path(name)
+    File.join(aruba.config.root_directory,
+        aruba.config.working_directory, "git", "#{name}.git")
+end
+
+Given("a git repository {string}") do |repo_name|
+    git_path = aruba_git_path(repo_name)
+    FileUtils.mkdir_p File.dirname(git_path)
+    step("I run `git --git-dir '#{git_path}' init`")
+end
+
+When("I push {string} to {string}") do |branch, repo_name|
+    git_path = aruba_git_path(repo_name)
+    step("I run `git push --tags '#{git_path}' '#{branch}'`")
+end

--- a/features/support/aruba.rb
+++ b/features/support/aruba.rb
@@ -11,9 +11,31 @@ Aruba.configure do |config|
     end
 end
 
+Before('@clobber-git') do |scenario|
+    FileUtils.rm_rf File.join(
+        aruba.config.root_directory, aruba.config.working_directory, "git")
+    FileUtils.rm_rf File.join(
+        aruba.config.root_directory, aruba.config.working_directory, "dev",
+            '.autoproj', 'remotes',
+            "git__home_doudou_dev_rock_and_syskit_dev_dev____"\
+            "git_rock_rock_and_syskit_package_set_git")
+end
+
+Before('@clobber-new_package_set') do |scenario|
+    FileUtils.rm_rf File.join(
+        aruba.config.root_directory, aruba.config.working_directory, "new_package_set")
+end
+
 After do |scenario|
+    autoproj_config_dir = File.join(
+        aruba.config.root_directory, aruba.config.working_directory, "dev", '.autoproj')
+    if File.directory?(autoproj_config_dir)
+        File.open(File.join(autoproj_config_dir, '.gitignore'), 'w') do |io|
+            io.puts "remotes/"
+        end
+    end
+
     if scenario.passed?
         save_state_after_scenario(scenario.feature.name, scenario.name)
     end
 end
-

--- a/features/support/aruba.rb
+++ b/features/support/aruba.rb
@@ -1,3 +1,4 @@
+require_relative './save_state'
 require 'aruba/cucumber'
 Aruba.configure do |config|
     checkout_name = File.basename(config.root_directory)
@@ -10,27 +11,9 @@ Aruba.configure do |config|
     end
 end
 
-def save_state_as_git_tag(tag_name, path)
-    git_dir = File.join(path, ".git")
-    if !File.directory?(git_dir)
-        if !system("git init", chdir: path, out: :close)
-            raise "Failed to create the git repository in #{path}"
-        end
-    end
-    if !system("git add .", chdir: path, out: :close) || !system("git commit --allow-empty -m '#{tag_name}'", chdir: path, out: :close)
-        raise "Failed to commit the current state"
-    end
-    if !system("git tag -f '#{tag_name}'", chdir: path, out: :close)
-        raise "Failed to create the git repository in #{git_dir}"
+After do |scenario|
+    if scenario.passed?
+        save_state_after_scenario(scenario.feature.name, scenario.name)
     end
 end
 
-After do |scenario|
-    if scenario.passed?
-        tag_name = "#{scenario.feature.name} - #{scenario.name}".gsub(/[^\w]+/, '_')
-        bundle_path = File.join(aruba.config.root_directory, aruba.config.working_directory, "dev", "bundles", "syskit_basics")
-        if File.directory?(bundle_path)
-            save_state_as_git_tag(tag_name, bundle_path)
-        end
-    end
-end

--- a/features/support/save_state.rb
+++ b/features/support/save_state.rb
@@ -1,0 +1,105 @@
+SAVED_REPOS = %w[.autoproj autoproj bundles/syskit_basics] unless defined? SAVED_REPOS
+
+def tag_name_from_feature_and_scenario(feature, scenario)
+    cleaned = [feature, scenario].
+        map { |name| name.gsub(/[^\w]+/, '_') }
+    cleaned.join('-')
+end
+
+def save_repo_state_as_git_tag(tag_name, path)
+    git_dir = File.join(path, ".git")
+    if !File.directory?(git_dir)
+        if !system("git init", chdir: path, out: :close)
+            raise "Failed to create the git repository in #{path}"
+        end
+    end
+    commit_successful = system("git", "add", ".", chdir: path, out: :close) &&
+        system("git", "commit", "--allow-empty", "-m", tag_name, chdir: path, out: :close)
+    unless commit_successful
+        raise "Failed to commit the current state"
+    end
+    if !system("git", "tag", "-f", tag_name, chdir: path, out: :close)
+        raise "Failed to create the git repository in #{git_dir}"
+    end
+end
+
+def find_expected_scenario(feature_file, scenario: ARGV[1])
+    features = []
+    File.readlines(feature_file).each do |line|
+        line = line.strip
+        if (feature_match = /^Feature:\s+(.*)$/.match(line))
+            features << [feature_match[1], []]
+        elsif (scenario_match = /^Scenario:\s+(.*)$/.match(line))
+            features.last[1] << scenario_match[1]
+        end
+    end
+
+    unless scenario
+        feature, scenarios = features.first
+        return [feature, scenarios.first]
+    end
+
+    rx = Regexp.new(scenario)
+
+    all_matches = []
+    features.each do |feature_names, scenarios|
+        matches = scenarios.grep(rx)
+        all_matches.concat(matches.map { |n| [feature_name, n] })
+    end
+
+    if all_matches.size == 1
+        return all_matches.first
+    else
+        raise Ambiguous, "#{scenario} matches more than one scenario "\
+            "in #{feature_file}: #{all_matches.map { |f, s| "#{f} - #{s}" }.join(", ")}"
+    end
+end
+
+def save_state_after_scenario(feature, scenario)
+    tag_name = tag_name_from_feature_and_scenario(feature, scenario)
+    SAVED_REPOS.each do |name|
+        full_path = File.join(
+            aruba.config.root_directory,
+            aruba.config.working_directory,
+            "dev", name)
+        if File.directory?(full_path)
+            save_repo_state_as_git_tag(tag_name, full_path)
+        end
+    end
+end
+
+def restore_state_before_scenario(feature, scenario, base_path)
+    scenario_tag_name = tag_name_from_feature_and_scenario(feature, scenario)
+    SAVED_REPOS.each do |name|
+        full_path = File.join(base_path, "dev", name)
+        if File.directory?(full_path)
+            repo_tags = IO.popen(["git", "--git-dir", "#{full_path}/.git", "tag"]) do |io|
+                io.readlines.map(&:chomp).sort
+            end
+            unless $?.success?
+                raise "failed to get tags from #{full_path}" 
+            end
+            _, tag_index = repo_tags.each_with_index.
+                find { |a, i| a == scenario_tag_name } ||
+                [nil, repo_tags.size]
+            before_tag = repo_tags[tag_index - 1] if tag_index > 0
+            if before_tag
+                puts "resetting #{full_path} to #{before_tag}"
+                puts "press ENTER to confirm"
+                STDIN.readline
+                reset_successful =
+                    system("git", "reset", "--hard", before_tag,
+                        chdir: full_path, out: :close) &&
+                    system("git", "clean", "-fdx", before_tag,
+                        chdir: full_path, out: :close)
+                puts "FAILED" unless reset_successful
+            else
+                puts "no tag found before #{scenario_tag_name} in #{full_path}, deleting"
+                puts "press ENTER to confirm"
+                STDIN.readline
+                FileUtils.rm_rf full_path
+            end
+        end
+    end
+end
+

--- a/source/basics/deployment.html.md
+++ b/source/basics/deployment.html.md
@@ -348,5 +348,10 @@ is to give you a feeling for Syskit's runtime workflow. Detailed explanations wi
 <iframe width="853" height="480" src="https://www.youtube.com/embed/JrgS23xEK9g?rel=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
 </div>
 
-**Next**: Before we move on to the Syskit runtime aspects, you may pass through an extension of the configuration code that [validates its consistency](validation.html). This is a more advanced topic, so you may also go straight to [the recap](recap.html) and go back to it at a later time.
+
+**Next**: Before we move on to the Syskit runtime aspects, you may pass
+*through an extension of the configuration code that [validates its
+*consistency](validation.html). This is a more advanced topic, so you may also
+*go straight to [publishing the package](publishing.html) and go back to it at
+*a later time.
 {: .next-page}

--- a/source/basics/index.html.md.erb
+++ b/source/basics/index.html.md.erb
@@ -37,9 +37,6 @@ The details will be here.
 </div>
 </div>
 
-
-{: .advanced-topic}
-
 ## Basic Concepts {#concepts}
 
 **Design and runtime** Rock is a model-based architecture. A Rock system is

--- a/source/basics/publishing.html.md
+++ b/source/basics/publishing.html.md
@@ -1,0 +1,91 @@
+---
+layout: documentation
+title: Publishing
+sort_info: 55
+---
+
+# Publishing the Bundle
+{:.no_toc}
+
+- TOC
+{:toc}
+
+In order to publish our bundle, sharing it with e.g. our coworkers, we actually
+have to do a few things:
+
+1.  Create a `manifest.xml` with the following contents:
+
+    ~~~xml
+    <package>
+        <description brief="Syskit Tutorial Bundle from 'Rock and Syskit'">
+        </description>
+
+        <depend package="bundles/common_models" />
+        <depend package="simulation/rock_gazebo" />
+        <depend package="control/orogen/cart_ctrl_wdls" />
+        <depend package="control/orogen/robot_frames" />
+    </package>
+    ~~~
+
+2.  You will obviously need to put the code somewhere. Let's assume it will
+    end up on GitHub. The repository naming convention is to separate the folder
+    names with dashes, so in this case, the repo would be named
+    `bundles-syskit_basics`. Let's use the `rock-core` organization as an
+    example.
+
+    Turn first the `bundles/syskit_basics` folder into a `git` repository, and
+    add the files we have created with:
+
+    ~~~
+    git init
+    git add .
+    git commit -m "Initial commit - Finished the Basics tutorial"
+    ~~~
+
+    Then create the repository and push to it (replacing the URL with your repository
+    URL):
+
+    ~~~
+    git push git@github.com:rock-core/bundles-syskit_basics master
+    ~~~
+
+3.  Create your own Autoproj project, on top of which you will be able to
+    expand your developments. This is described in [the Starting A New Project
+    section](../workspace/setup.html) in the _Workspace and Packages_ chapter. Read this
+    chapter, and apply it here.
+    
+    Make sure you added the newly created package set to both the
+    `package_sets` and the `layout`, as the "Starting a new project' section
+    instructed you to.
+
+4.  Finally, add the bundle to your newly create package set. Edit the
+    `packages.autobuild` file and add
+
+    ~~~ruby
+    bundle_package "bundles/syskit_basics"
+    ~~~
+
+    And add a corresponding entry in the package set's `source.yml`, which would
+    look like
+
+    ~~~yaml
+    - bundles/syskit_basics:
+      github: rock-core/bundles-syskit_basics
+    ~~~
+
+    Check that things resolve properly with `autoproj show syskit_basics` and do a
+    `aup -n syskit_basics` to verify that the repository is properly setup.
+
+5.  Because the bundle is part of the package set, and because the bundle depends on
+    the `control/orogen/cart_ctrl_wdls` and `control/orogen/robot_frames` packages,
+    they should not be listed anymore within the workspace manifest. Removes them
+    from `autoproj/manifest`.
+
+    The general best practice is to basically ensure that your projects packages depend
+    on what they need, and then either depend on the whole package set (common on
+    developer machines), or on specific packages. The latter is usually the bundle,
+    which happens on the robot machines themselves.
+
+5.  Publish the changes from your package set and main build configuration.
+  
+Let's finally go to the [section's recap](recap.html)

--- a/source/basics/recap.html.md
+++ b/source/basics/recap.html.md
@@ -20,6 +20,10 @@ software
 - packages are also [added during development](composition.html#add_package),
   when the functionality is required
 
+You will ultimately [create your own build configuration and package
+sets](publishing.html) to share the state of your workspace with your
+coworkers.
+
 ### Bundles
 
 [Bundles](getting_started.html) are the package within which we create Syskit models and code. It is the _place of integration_.

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -59,3 +59,6 @@ img.fullwidth {
         position: relative;
     }
 }
+a > code {
+    color: #337ab7;
+}

--- a/source/workspace/setup.html.md
+++ b/source/workspace/setup.html.md
@@ -18,9 +18,10 @@ either [the Rock bootstrap](../basics/installation.html) or a project's main
 build configuration.
 
 After having bootstrapped, the "source" build configuration is checked out in
-the `autoproj/` folder at the root of the workspace. Push it to a repository
-you would have created to hold your own project's build configuration. You can
-then change Autoproj's configuration to track it instead of the Rock build with
+the `autoproj/` folder at the root of the workspace. Commit the folder's current
+state, push it to a repository you would have created to hold your own
+project's build configuration. You can then change Autoproj's configuration
+to track it instead of the Rock build with
 
 ~~~
 autoproj switch-config git URL
@@ -49,12 +50,23 @@ just `company` for the organization one. For example purposes, the rest of this
 page will use `company.project` as the package set name.
 
 Assuming you're using git and github, create a new repository on github,
-following the `company.project-package_set` pattern. Create an empty directory
-and do (replacing URL by your repository's URL):
+following the `company.project-package_set` pattern.
+
+In the context of the [Basics section](../basics/publishing.html), a good
+name for the package set would be `rock.rock_and_syskit` (i.e. `rock`
+organization, the `rock_and_syskit` project). The buildconf would be saved
+in a repository named `rock.rock_and_syskit-buildconf` and the package set
+in `rock.rock_and_syskit-package_set`.
+
+To create a minimal package set, create an empty directory (the name does not
+matter) and do (replacing the name by your actual package set name and the
+URL by your repository's URL):
 
 ~~~
 git init
 echo "name: company.project" > source.yml
+echo "version_control:" >> source.yml
+echo "overrides:" >> source.yml
 touch packages.autobuild packages.osdeps init.rb overrides.rb
 git add .
 git commit -m "Initial commit"
@@ -87,6 +99,23 @@ name in the `layout` section:
 ~~~yaml
 layout:
 - company.project
+~~~
+
+E.g. for the Basics tutorial, assuming it is stored on the `rock-core` organization,
+the whole manifest would look like:
+
+~~~yaml
+package_sets:
+   - github: rock-core/package_set
+   - github: rock-core/rock-package_set
+   - github: rock-tutorials/tutorials-package_set
+   - github: rock-gazebo/package_set
+   - github: rock-core/rock.rock_and_syskit-package_set
+
+layout:
+   - rock.core
+   - rock.gazebo
+   - rock.rock_and_syskit
 ~~~
 
 There are other import possibilities, listed in the [adding new


### PR DESCRIPTION
This completes the cucumber features to cover the whole Basics section as well as the setup in the integration tests. Moreover, it adds a way to snapshot and restore a previous workspace state (a state from a previous cucumber scenario) to make it a lot easier to debug the features.

It adds the "Publish your package" section in Basics, and fixes a small styling issue with links and code blocks