### PR TITLE
fix: deploy via middleman-deploy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'susy', "~>2.2"
 gem 'middleman-navtree', git: 'https://github.com/doudou/middleman-navtree'
 gem 'middleman-syntax'
 gem 'middleman-livereload'
-gem 'middleman-gh-pages'
+gem 'middleman-deploy', '~> 2.0.0.pre.alpha'
 
 # For faster file watcher updates on Windows:
 gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,0 @@
-require 'middleman-gh-pages'

--- a/config.rb
+++ b/config.rb
@@ -19,6 +19,12 @@ activate :navtree do |options|
     options.ext_whitelist = [] # If you add extensions (like '.md') to this array, it builds a whitelist of filetypes for inclusion in the navtree.
     options.directory_indexes << 'index.html.md' << 'index.html.md.erb'
 end
+activate :deploy do |deploy|
+    deploy.deploy_method = :git
+    deploy.remote = "git@github.com:rock-core/rock-and-syskit.git"
+    deploy.branch = "gh-pages"
+    deploy.build_before = true
+end
 
 # Per-page layout changes:
 #


### PR DESCRIPTION
middleman-gh-pages does not seem to properly work anymore.
middleman-deploy seems to be abandoned, but the pre-release version
supports middleman 4 and works for github pages.