### PR TITLE
fix: depend on middleman 4.4.X instead of 4.X

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 # Middleman Gems
-gem 'middleman', '~> 4.4'
+gem 'middleman', '~> 4.4.0'
 gem 'sass'
 gem 'bootstrap-sass'
 gem 'susy', "~>2.2"


### PR DESCRIPTION
Middleman 4.5.0 is breaking, downgrade for now to investigate later