### PR TITLE
Fix command to enable tests in testing.html.md

### DIFF
--- a/source/workspace/testing.html.md
+++ b/source/workspace/testing.html.md
@@ -27,7 +27,7 @@ done by _enabling_ the tests for the package you're interested in:
 
 ~~~
 cd path/to/my/package
-autoproj test enable
+autoproj test enable .
 aup --checkout-only
 amake
 ~~~


### PR DESCRIPTION
In the instructions on how to enable tests for a single package: `autoproj test enable` -> `autoproj test enable .`